### PR TITLE
feat(ref): diy ref 子命令 + TOML 解析重构

### DIFF
--- a/pkgs/diy-cli/src/diycli/_cli.py
+++ b/pkgs/diy-cli/src/diycli/_cli.py
@@ -8,6 +8,7 @@ from cyclopts import App, Parameter, Group
 from ._log import set_verbosity, logger
 from ._sync import sync_dependencies
 from .llm import llm_app
+from .ref import ref_app
 from .llm.auth import load_dotenv
 
 _GLOBAL_GROUP = Group("全局选项")
@@ -42,6 +43,7 @@ def sync_cmd():
         sys.exit(1)
 
 app.command(llm_app)
+app.command(ref_app)
 
 @app.default
 def root(verbose: VerboseRoot = 0):

--- a/pkgs/diy-cli/src/diycli/_sync.py
+++ b/pkgs/diy-cli/src/diycli/_sync.py
@@ -152,7 +152,7 @@ def get_workspace_packages(root_dir: Path) -> Dict[str, WorkspaceInfo]:
                 content = f.read()
             import re
             # Extract tool.uv.workspace.members or tool.poetry.workspace.members
-            workspace_match = re.search(r'\[tool\.(?:uv|poetry)\.workspace\][\s\S]*?members\s*=\s*\[(.*?)\]', content)
+            workspace_match = re.search(r'\[tool\.(?:uv|poetry)\.workspace\][\s\S]*?members\s*=\s*\[(.*?)\]', content, re.DOTALL)
             if workspace_match:
                 for pattern in re.findall(r'"([^"]+)"', workspace_match.group(1)):
                     base_dir_str = pattern.replace("/*", "")

--- a/pkgs/diy-cli/src/diycli/_sync.py
+++ b/pkgs/diy-cli/src/diycli/_sync.py
@@ -61,18 +61,15 @@ def get_workspace_packages(root_dir: Path) -> Dict[str, WorkspaceInfo]:
         deps = {}
         if pyproject_path.exists():
             try:
-                with open(pyproject_path, "r", encoding="utf-8") as f:
-                    content = f.read()
-                import re
-                deps_match = re.search(r'dependencies\s*=\s*\[(.*?)\]', content, re.DOTALL)
-                if deps_match:
-                    dep_list = deps_match.group(1)
-                    for dep_str in re.findall(r'"([^"]+)"', dep_list):
-                        d_parts = re.split(r'[>=<]', dep_str)
-                        if d_parts:
-                            d_name = d_parts[0].strip()
-                            d_ver = dep_str[len(d_name):].strip() or "*"
-                            deps[d_name] = d_ver
+                import tomllib
+                with open(pyproject_path, "rb") as f:
+                    pyproject = tomllib.load(f)
+                for dep_str in pyproject.get("project", {}).get("dependencies", []):
+                    d_parts = re.split(r'[>=<]', dep_str)
+                    if d_parts:
+                        d_name = d_parts[0].strip()
+                        d_ver = dep_str[len(d_name):].strip() or "*"
+                        deps[d_name] = d_ver
             except Exception: pass
         return deps
 
@@ -101,13 +98,12 @@ def get_workspace_packages(root_dir: Path) -> Dict[str, WorkspaceInfo]:
         # 无论有无 deps，都尝试从 pyproject.toml 读取 name/version
         if not name and pyproject_path.exists():
             try:
-                with open(pyproject_path, "r", encoding="utf-8") as f:
-                    content = f.read()
-                import re
-                name_match = re.search(r'name\s*=\s*"([^"]+)"', content)
-                if name_match: name = name_match.group(1)
-                version_match = re.search(r'version\s*=\s*"([^"]+)"', content)
-                if version_match: version = version_match.group(1)
+                import tomllib
+                with open(pyproject_path, "rb") as f:
+                    pyproject = tomllib.load(f)
+                proj = pyproject.get("project", {})
+                name = proj.get("name", "")
+                version = proj.get("version", version)
             except Exception: pass
         
         if name:
@@ -148,24 +144,27 @@ def get_workspace_packages(root_dir: Path) -> Dict[str, WorkspaceInfo]:
     root_pyproject_path = root_dir / "pyproject.toml"
     if root_pyproject_path.exists():
         try:
-            with open(root_pyproject_path, "r", encoding="utf-8") as f:
-                content = f.read()
-            import re
-            # Extract tool.uv.workspace.members or tool.poetry.workspace.members
-            workspace_match = re.search(r'\[tool\.(?:uv|poetry)\.workspace\][\s\S]*?members\s*=\s*\[(.*?)\]', content, re.DOTALL)
-            if workspace_match:
-                for pattern in re.findall(r'"([^"]+)"', workspace_match.group(1)):
-                    base_dir_str = pattern.replace("/*", "")
-                    full_base_dir = root_dir / base_dir_str
-                    if full_base_dir.exists() and full_base_dir.is_dir():
-                        if "/*" in pattern:
-                            for item in full_base_dir.iterdir():
-                                if item.is_dir():
-                                    info = get_dir_info(item, str(item.relative_to(root_dir)))
-                                    if info: workspace_map[info.name] = info
-                        else:
-                            info = get_dir_info(full_base_dir, str(full_base_dir.relative_to(root_dir)))
-                            if info: workspace_map[info.name] = info
+            import tomllib
+            with open(root_pyproject_path, "rb") as f:
+                pyproject = tomllib.load(f)
+            # uv.workspace.members 或 poetry.workspace.members
+            workspace_cfg = (
+                pyproject.get("tool", {}).get("uv", {}).get("workspace", {})
+                or pyproject.get("tool", {}).get("poetry", {}).get("workspace", {})
+            )
+            members = workspace_cfg.get("members", [])
+            for pattern in members:
+                base_dir_str = pattern.replace("/*", "")
+                full_base_dir = root_dir / base_dir_str
+                if full_base_dir.exists() and full_base_dir.is_dir():
+                    if "/*" in pattern:
+                        for item in full_base_dir.iterdir():
+                            if item.is_dir():
+                                info = get_dir_info(item, str(item.relative_to(root_dir)))
+                                if info: workspace_map[info.name] = info
+                    else:
+                        info = get_dir_info(full_base_dir, str(full_base_dir.relative_to(root_dir)))
+                        if info: workspace_map[info.name] = info
         except Exception: pass
 
     # 4. Check pkgs/ directory (fallback for both)
@@ -606,13 +605,14 @@ def load_uv_lock(root_dir: Path) -> Dict[str, str]:
     resolved = {}
     if lock_path.exists():
         try:
-            with open(lock_path, "r", encoding="utf-8") as f:
-                content = f.read()
-            import re
-            for block, _ in re.findall(r'\[\[package\]\](.*?)(\n\n|(?=\[\[package\]\])|$)', content, re.DOTALL):
-                name = re.search(r'name\s*=\s*"([^"]+)"', block)
-                ver = re.search(r'version\s*=\s*"([^"]+)"', block)
-                if name and ver: resolved[name.group(1)] = ver.group(1)
+            import tomllib
+            with open(lock_path, "rb") as f:
+                data = tomllib.load(f)
+            for pkg in data.get("package", []):
+                name = pkg.get("name")
+                ver = pkg.get("version")
+                if name and ver:
+                    resolved[name] = ver
         except Exception: pass
     return resolved
 
@@ -656,16 +656,14 @@ def sync_dependencies():
         
     if pyproject_path.exists():
         try:
-            with open(pyproject_path, "r", encoding="utf-8") as f:
-                content = f.read()
-            import re
-            m = re.search(r'dependencies\s*=\s*\[(.*?)\]', content, re.DOTALL)
-            if m:
-                for d in re.findall(r'"([^"]+)"', m.group(1)):
-                    parts = re.split(r'[>=<]', d)
-                    if parts:
-                        name = parts[0].strip()
-                        all_deps[("python", name)] = uv_lock.get(name, d[len(name):].strip() or "*")
+            import tomllib
+            with open(pyproject_path, "rb") as f:
+                pyproject = tomllib.load(f)
+            for d in pyproject.get("project", {}).get("dependencies", []):
+                parts = re.split(r'[>=<]', d)
+                if parts:
+                    name = parts[0].strip()
+                    all_deps[("python", name)] = uv_lock.get(name, d[len(name):].strip() or "*")
         except Exception: pass
     
     # 合并 workspace packages 的依赖

--- a/pkgs/diy-cli/src/diycli/ref.py
+++ b/pkgs/diy-cli/src/diycli/ref.py
@@ -1,0 +1,277 @@
+"""diy ref — 参考仓库管理命令"""
+
+import sys
+import yaml
+from pathlib import Path
+from typing import Optional
+from cyclopts import App, Parameter
+
+from ._log import logger
+from ._sync import (
+    find_project_root,
+    build_ref_lock,
+    write_ref_lock_file,
+    SyncResult,
+    GLOBAL_CACHE_DIR,
+)
+
+log = logger.with_tag("ref")
+
+ref_app = App(
+    name="ref",
+    help="参考仓库管理 — list/add/remove/sync/status",
+)
+
+
+def _load_ref_lock(root_dir: Path) -> dict:
+    """加载 .diy/ref.lock.yaml"""
+    lock_path = root_dir / ".diy" / "ref.lock.yaml"
+    if not lock_path.exists():
+        return {}
+    try:
+        with open(lock_path, "r", encoding="utf-8") as f:
+            data = yaml.safe_load(f) or {}
+        return data.get("refs", {})
+    except Exception:
+        return {}
+
+
+def _load_diy_yaml(root_dir: Path) -> dict:
+    """加载 diy.yaml"""
+    diy_yaml = root_dir / "diy.yaml"
+    if not diy_yaml.exists():
+        return {}
+    try:
+        with open(diy_yaml, "r", encoding="utf-8") as f:
+            return yaml.safe_load(f) or {}
+    except Exception:
+        return {}
+
+
+def _save_diy_yaml(root_dir: Path, config: dict):
+    """保存 diy.yaml"""
+    diy_yaml = root_dir / "diy.yaml"
+    try:
+        with open(diy_yaml, "w", encoding="utf-8") as f:
+            yaml.dump(config, f, default_flow_style=False, allow_unicode=True)
+    except Exception as e:
+        log.error(f"保存 diy.yaml 失败: {e}")
+        raise
+
+
+def _parse_ref_key(key: str) -> tuple[str, str]:
+    """解析 ref key 为 (type, name)"""
+    if ":" in key:
+        parts = key.split(":", 1)
+        return parts[0], parts[1]
+    return "unknown", key
+
+
+@ref_app.command(name="list")
+def ref_list(
+    verbose: int = 0,
+):
+    """列出所有已同步的 ref"""
+    root_dir = find_project_root()
+    refs = _load_ref_lock(root_dir)
+    config = _load_diy_yaml(root_dir)
+    sources = config.get("sources", [])
+
+    if not refs:
+        log.info("暂无已同步的 ref")
+        return
+
+    # 分类
+    dep_refs = {}
+    source_refs = {}
+    for key, path in refs.items():
+        ref_type, name = _parse_ref_key(key)
+        if ref_type == "source":
+            source_refs[name] = path
+        else:
+            dep_refs[key] = path
+
+    # 输出
+    from rich.console import Console
+    from rich.table import Table
+    from rich import box
+
+    console = Console()
+
+    if source_refs:
+        table = Table(title="Sources (参考仓库)", box=box.SIMPLE)
+        table.add_column("名称", style="cyan")
+        table.add_column("路径", style="green")
+        table.add_column("配置", style="dim")
+
+        # 匹配 diy.yaml sources
+        source_map = {}
+        for s in sources:
+            if "@" in s:
+                idx = s.rfind("@")
+                if idx > 7:
+                    url, ver = s[:idx], s[idx+1:]
+                else:
+                    url, ver = s, ""
+            else:
+                url, ver = s, ""
+            # 提取 owner/repo
+            from ._sync import parse_repo_url
+            repo_info = parse_repo_url(url)
+            if repo_info:
+                name = f"{repo_info.owner}/{repo_info.repo}"
+                source_map[name] = s
+
+        for name, path in sorted(source_refs.items()):
+            config_str = source_map.get(name, "")
+            table.add_row(name, path, config_str)
+
+        console.print(table)
+        console.print()
+
+    if dep_refs:
+        table = Table(title="Dependencies (依赖源码)", box=box.SIMPLE)
+        table.add_column("类型", style="magenta")
+        table.add_column("名称", style="cyan")
+        table.add_column("路径", style="green")
+
+        for key, path in sorted(dep_refs.items()):
+            ref_type, name = _parse_ref_key(key)
+            table.add_row(ref_type, name, path)
+
+        console.print(table)
+
+    console.print(f"\n总计: {len(source_refs)} sources, {len(dep_refs)} deps")
+
+
+@ref_app.command(name="add")
+def ref_add(
+    url: str,
+    version: Optional[str] = None,
+    verbose: int = 0,
+):
+    """添加参考仓库"""
+    root_dir = find_project_root()
+    config = _load_diy_yaml(root_dir)
+
+    # 确保 sources 列表存在
+    if "sources" not in config:
+        config["sources"] = []
+
+    # 构建 source spec
+    spec = url
+    if version:
+        spec = f"{url}@{version}"
+
+    # 检查是否已存在
+    from ._sync import parse_repo_url
+    repo_info = parse_repo_url(url)
+    if not repo_info:
+        log.error(f"无法解析 URL: {url}")
+        sys.exit(1)
+
+    name = f"{repo_info.owner}/{repo_info.repo}"
+    for existing in config["sources"]:
+        existing_info = parse_repo_url(existing.split("@")[0] if "@" in existing else existing)
+        if existing_info and f"{existing_info.owner}/{existing_info.repo}" == name:
+            log.warning(f"Source 已存在: {name}，跳过")
+            return
+
+    # 添加到 diy.yaml
+    config["sources"].append(spec)
+    _save_diy_yaml(root_dir, config)
+    log.success(f"已添加 source: {spec}")
+
+
+@ref_app.command(name="remove")
+def ref_remove(
+    name: str,
+    verbose: int = 0,
+):
+    """移除参考仓库"""
+    root_dir = find_project_root()
+    config = _load_diy_yaml(root_dir)
+    sources = config.get("sources", [])
+
+    if not sources:
+        log.warning("diy.yaml 中没有 sources")
+        return
+
+    from ._sync import parse_repo_url
+
+    # 查找匹配的 source
+    found = False
+    new_sources = []
+    for s in sources:
+        url_part = s.split("@")[0] if "@" in s else s
+        repo_info = parse_repo_url(url_part)
+        if repo_info:
+            current_name = f"{repo_info.owner}/{repo_info.repo}"
+            if current_name == name or url_part == name or s == name:
+                found = True
+                log.info(f"移除: {s}")
+                continue
+        new_sources.append(s)
+
+    if not found:
+        log.error(f"未找到匹配的 source: {name}")
+        sys.exit(1)
+
+    config["sources"] = new_sources
+    _save_diy_yaml(root_dir, config)
+    log.success(f"已移除 source: {name}")
+
+
+@ref_app.command(name="sync")
+def ref_sync(
+    verbose: int = 0,
+):
+    """同步所有 ref（依赖 + sources）"""
+    from ._sync import sync_dependencies
+    sync_dependencies()
+
+
+@ref_app.command(name="status")
+def ref_status(
+    verbose: int = 0,
+):
+    """检查 ref 状态"""
+    root_dir = find_project_root()
+    refs = _load_ref_lock(root_dir)
+    config = _load_diy_yaml(root_dir)
+    sources = config.get("sources", [])
+
+    if not refs:
+        log.info("暂无已同步的 ref")
+        return
+
+    from rich.console import Console
+    from rich.table import Table
+    from rich import box
+
+    console = Console()
+    table = Table(title="Ref 状态", box=box.SIMPLE)
+    table.add_column("Key", style="cyan")
+    table.add_column("路径", style="green")
+    table.add_column("状态", justify="center")
+
+    home = Path.home()
+    ok_count = 0
+    missing_count = 0
+
+    for key, path in sorted(refs.items()):
+        # 展开 ~
+        if path.startswith("~/"):
+            abs_path = home / path[2:]
+        else:
+            abs_path = Path(path)
+
+        if abs_path.exists():
+            table.add_row(key, path, "[green]✓[/green]")
+            ok_count += 1
+        else:
+            table.add_row(key, path, "[red]✗ 缺失[/red]")
+            missing_count += 1
+
+    console.print(table)
+    console.print(f"\n状态: [green]{ok_count} 正常[/green], [red]{missing_count} 缺失[/red]")


### PR DESCRIPTION
## 变更

### 1. 新增 diy ref 子命令

管理参考仓库的统一入口：

- `diy ref list` — 列出所有已同步的 ref
- `diy ref add <url>[@ver]` — 添加 source 到 diy.yaml
- `diy ref remove <name>` — 从 diy.yaml 移除 source
- `diy ref sync` — 同步所有 ref
- `diy ref status` — 检查 ref 状态

### 2. 修复 workspace 包识别

pyproject.toml 的 workspace members 跨多行，正则缺 re.DOTALL 导致 workspace 包漏检。

### 3. TOML 解析重构

sync.py 中所有 TOML 解析从正则改为 tomllib（标准库），更可靠。
