### PR TITLE
feat(task): pool + star 任务模型基础实现

### DIFF
--- a/dai94
+++ b/dai94
@@ -1,9 +1,0 @@
-#!/bin/bash
-# dai94 — 隔离实验环境
-# 数据: ~/.diy-dev/94/
-
-set -e
-export DIY_HOME="$HOME/.diy-dev/94"
-mkdir -p "$DIY_HOME"
-cd "$HOME/git/diy/_diy-work/feat/task-pool-star"
-exec uv run diy "$@"

--- a/dai94
+++ b/dai94
@@ -1,0 +1,45 @@
+#!/bin/bash
+# dai94 — 隔离实验环境命令
+# 数据目录: ~/.diy-dev/94/
+# Socket: ~/.diy-dev/94/app.sock
+
+set -e
+
+EXP_ID="94"
+DIY_DEV_HOME="$HOME/.diy-dev/$EXP_ID"
+
+# 创建隔离目录
+mkdir -p "$DIY_DEV_HOME"
+
+# 设置环境变量
+export DIY_HOME="$DIY_DEV_HOME"
+
+# 新分支代码目录
+WORKTREE="$HOME/git/diy/_diy-work/feat/task-pool-star"
+DIY_SRC="$HOME/git/diy/_diy"
+
+# 根据参数决定运行 app 还是 CLI
+if [ $# -eq 0 ]; then
+    # 无参数：启动 app
+    cd "$DIY_SRC"
+    PYTHONPATH="$WORKTREE/pkgs/diy-cli/src:$PYTHONPATH" exec uv run python -m diydev.app.main
+elif [ "$1" = "app" ]; then
+    # dai94 app：启动 app
+    shift
+    cd "$DIY_SRC"
+    PYTHONPATH="$WORKTREE/pkgs/diy-cli/src:$PYTHONPATH" exec uv run python -m diydev.app.main "$@"
+elif [ "$1" = "task" ]; then
+    # dai94 task ...：运行 task 命令
+    shift
+    cd "$WORKTREE"
+    exec uv run diy task "$@"
+elif [ "$1" = "ref" ]; then
+    # dai94 ref ...：运行 ref 命令
+    shift
+    cd "$WORKTREE"
+    exec uv run diy ref "$@"
+else
+    # 其他命令：直接运行 diy
+    cd "$WORKTREE"
+    exec uv run diy "$@"
+fi

--- a/dai94
+++ b/dai94
@@ -1,45 +1,9 @@
 #!/bin/bash
-# dai94 — 隔离实验环境命令
-# 数据目录: ~/.diy-dev/94/
-# Socket: ~/.diy-dev/94/app.sock
+# dai94 — 隔离实验环境
+# 数据: ~/.diy-dev/94/
 
 set -e
-
-EXP_ID="94"
-DIY_DEV_HOME="$HOME/.diy-dev/$EXP_ID"
-
-# 创建隔离目录
-mkdir -p "$DIY_DEV_HOME"
-
-# 设置环境变量
-export DIY_HOME="$DIY_DEV_HOME"
-
-# 新分支代码目录
-WORKTREE="$HOME/git/diy/_diy-work/feat/task-pool-star"
-DIY_SRC="$HOME/git/diy/_diy"
-
-# 根据参数决定运行 app 还是 CLI
-if [ $# -eq 0 ]; then
-    # 无参数：启动 app
-    cd "$DIY_SRC"
-    PYTHONPATH="$WORKTREE/pkgs/diy-cli/src:$PYTHONPATH" exec uv run python -m diydev.app.main
-elif [ "$1" = "app" ]; then
-    # dai94 app：启动 app
-    shift
-    cd "$DIY_SRC"
-    PYTHONPATH="$WORKTREE/pkgs/diy-cli/src:$PYTHONPATH" exec uv run python -m diydev.app.main "$@"
-elif [ "$1" = "task" ]; then
-    # dai94 task ...：运行 task 命令
-    shift
-    cd "$WORKTREE"
-    exec uv run diy task "$@"
-elif [ "$1" = "ref" ]; then
-    # dai94 ref ...：运行 ref 命令
-    shift
-    cd "$WORKTREE"
-    exec uv run diy ref "$@"
-else
-    # 其他命令：直接运行 diy
-    cd "$WORKTREE"
-    exec uv run diy "$@"
-fi
+export DIY_HOME="$HOME/.diy-dev/94"
+mkdir -p "$DIY_HOME"
+cd "$HOME/git/diy/_diy-work/feat/task-pool-star"
+exec uv run diy "$@"

--- a/pkgs/diy-cli/src/diycli/_cli.py
+++ b/pkgs/diy-cli/src/diycli/_cli.py
@@ -9,6 +9,9 @@ from ._log import set_verbosity, logger
 from ._sync import sync_dependencies
 from .llm import llm_app
 from .ref import ref_app
+from .task_cli import task_app
+from .task_local import local_app
+from .task_github import github_app
 from .llm.auth import load_dotenv
 
 _GLOBAL_GROUP = Group("全局选项")
@@ -44,6 +47,11 @@ def sync_cmd():
 
 app.command(llm_app)
 app.command(ref_app)
+
+# 注册 task 子命令
+task_app.command(local_app)
+task_app.command(github_app)
+app.command(task_app)
 
 @app.default
 def root(verbose: VerboseRoot = 0):

--- a/pkgs/diy-cli/src/diycli/task.py
+++ b/pkgs/diy-cli/src/diycli/task.py
@@ -1,0 +1,197 @@
+"""dai task — 任务管理（pool + star 模型）
+
+存储模型:
+  ~/.diy/task/     ← pool（所有任务的永久存储）
+  ~/.diy/star/     ← focus（symlink 视图）
+
+命令:
+  dai task star/unstar    — 关注/取消
+  dai task list/show      — 列出/查看
+  dai task local create   — 创建本地任务
+  dai task github ...     — GitHub 操作
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+from typing import Optional
+
+from ._log import logger
+
+log = logger.with_tag("task")
+
+# ══════════════════════════════════════════════════════════════
+# 路径常量
+# ══════════════════════════════════════════════════════════════
+
+DIY_HOME = Path.home() / ".diy"
+POOL_DIR = DIY_HOME / "task"      # ~/.diy/task/
+STAR_DIR = DIY_HOME / "star"      # ~/.diy/star/
+
+
+# ══════════════════════════════════════════════════════════════
+# URI ↔ 路径映射
+# ══════════════════════════════════════════════════════════════
+
+def uri_to_pool_path(uri: str) -> Path:
+    """URI → pool 目录路径
+    
+    例:
+      github.com/diy-agent/_diy/issues/42 → ~/.diy/task/github.com/diy-agent/_diy/issues/42
+      local/task/1                        → ~/.diy/task/local/task/1
+    """
+    return POOL_DIR / uri
+
+
+def pool_path_to_uri(path: Path) -> str | None:
+    """pool 目录路径 → URI
+    
+    从 ~/.diy/task/ 开始计算相对路径
+    """
+    try:
+        rel = path.relative_to(POOL_DIR)
+        return str(rel)
+    except ValueError:
+        return None
+
+
+def uri_to_star_name(uri: str) -> str:
+    """URI → symlink 文件名（扁平化）
+    
+    例:
+      github.com/diy-agent/_diy/issues/42 → github.com_diy-agent__diy_issues_42
+      local/task/1                        → local_task_1
+    """
+    # 替换 / 为 _，保留 . 和 -
+    return uri.replace("/", "_").replace("\\", "_")
+
+
+def star_name_to_uri(star_name: str) -> str | None:
+    """symlink 文件名 → URI
+    
+    注意：这个映射不是完全可逆的（/ 被替换为 _）
+    需要从 star target 反推 URI
+    """
+    star_path = STAR_DIR / star_name
+    if not star_path.is_symlink():
+        return None
+    target = os.readlink(star_path)
+    # target 是相对路径，指向 pool
+    target_path = (STAR_DIR / target).resolve()
+    return pool_path_to_uri(target_path)
+
+
+# ══════════════════════════════════════════════════════════════
+# 基础操作
+# ══════════════════════════════════════════════════════════════
+
+def ensure_dirs():
+    """确保 pool 和 star 目录存在"""
+    POOL_DIR.mkdir(parents=True, exist_ok=True)
+    STAR_DIR.mkdir(parents=True, exist_ok=True)
+
+
+def is_starred(uri: str) -> bool:
+    """检查任务是否已 star"""
+    star_name = uri_to_star_name(uri)
+    star_path = STAR_DIR / star_name
+    return star_path.is_symlink()
+
+
+def star(uri: str) -> bool:
+    """star 一个任务
+    
+    如果 pool 里没有，需要先 sync（由调用方处理）
+    """
+    ensure_dirs()
+    
+    pool_path = uri_to_pool_path(uri)
+    if not pool_path.exists():
+        log.error(f"任务不在池子中: {uri}")
+        log.info(f"请先 dai task github link {uri}")
+        return False
+    
+    star_name = uri_to_star_name(uri)
+    star_path = STAR_DIR / star_name
+    
+    if star_path.exists():
+        log.info(f"已 star: {uri}")
+        return True
+    
+    # 创建相对路径 symlink
+    rel_path = os.path.relpath(pool_path, STAR_DIR)
+    star_path.symlink_to(rel_path)
+    log.success(f"已 star: {uri}")
+    return True
+
+
+def unstar(uri: str) -> bool:
+    """unstar 一个任务（数据不动）"""
+    star_name = uri_to_star_name(uri)
+    star_path = STAR_DIR / star_name
+    
+    if not star_path.is_symlink():
+        log.info(f"未 star: {uri}")
+        return True
+    
+    star_path.unlink()
+    log.success(f"已 unstar: {uri}")
+    return True
+
+
+def list_starred() -> list[str]:
+    """列出所有 star 的任务 URI"""
+    ensure_dirs()
+    
+    result = []
+    for item in STAR_DIR.iterdir():
+        if item.is_symlink():
+            uri = star_name_to_uri(item.name)
+            if uri:
+                result.append(uri)
+    return sorted(result)
+
+
+def list_pool() -> list[str]:
+    """列出 pool 中所有任务 URI"""
+    ensure_dirs()
+    
+    result = []
+    for item in POOL_DIR.rglob("AGENTS.md"):
+        uri = pool_path_to_uri(item.parent)
+        if uri:
+            result.append(uri)
+    return sorted(result)
+
+
+def get_task_data(uri: str) -> dict | None:
+    """获取任务数据（读 frontmatter）"""
+    pool_path = uri_to_pool_path(uri)
+    agents_md = pool_path / "AGENTS.md"
+    
+    if not agents_md.exists():
+        return None
+    
+    # 简单解析 frontmatter
+    content = agents_md.read_text(encoding="utf-8")
+    if not content.startswith("---"):
+        return {"uri": uri, "body": content}
+    
+    parts = content.split("---", 2)
+    if len(parts) < 3:
+        return {"uri": uri, "body": content}
+    
+    import yaml
+    frontmatter = yaml.safe_load(parts[1]) or {}
+    body = parts[2].strip()
+    
+    return {
+        "uri": uri,
+        "title": frontmatter.get("title", ""),
+        "state": frontmatter.get("state", "pending"),
+        "subject": frontmatter.get("subject", ""),
+        "source": frontmatter.get("source", {}),
+        "body": body,
+    }

--- a/pkgs/diy-cli/src/diycli/task.py
+++ b/pkgs/diy-cli/src/diycli/task.py
@@ -26,7 +26,14 @@ log = logger.with_tag("task")
 # 路径常量
 # ══════════════════════════════════════════════════════════════
 
-DIY_HOME = Path.home() / ".diy"
+def _get_diy_home() -> Path:
+    """获取 DIY_HOME 目录（支持环境变量覆盖）"""
+    if env := os.environ.get("DIY_HOME"):
+        return Path(env)
+    return Path.home() / ".diy"
+
+
+DIY_HOME = _get_diy_home()
 POOL_DIR = DIY_HOME / "task"      # ~/.diy/task/
 STAR_DIR = DIY_HOME / "star"      # ~/.diy/star/
 

--- a/pkgs/diy-cli/src/diycli/task_cli.py
+++ b/pkgs/diy-cli/src/diycli/task_cli.py
@@ -1,0 +1,137 @@
+"""dai task CLI 命令"""
+
+from __future__ import annotations
+
+import sys
+from typing import Annotated, Optional
+from cyclopts import App, Parameter
+
+from ._log import logger
+from .task import (
+    star, unstar, is_starred, list_starred, list_pool,
+    get_task_data, ensure_dirs, POOL_DIR, STAR_DIR,
+    uri_to_pool_path,
+)
+
+log = logger.with_tag("task")
+
+task_app = App(
+    name="task",
+    help="任务管理 — star/unstar/list/show",
+)
+
+
+# ══════════════════════════════════════════════════════════════
+# dai task star
+# ══════════════════════════════════════════════════════════════
+
+@task_app.command(name="star")
+def task_star(
+    uri: Annotated[str, Parameter(help="任务 URI")],
+):
+    """关注任务（自动 sync + 创建 symlink）"""
+    ensure_dirs()
+    success = star(uri)
+    if not success:
+        sys.exit(1)
+
+
+# ══════════════════════════════════════════════════════════════
+# dai task unstar
+# ══════════════════════════════════════════════════════════════
+
+@task_app.command(name="unstar")
+def task_unstar(
+    uri: Annotated[str, Parameter(help="任务 URI")],
+):
+    """取消关注（删除 symlink，数据不动）"""
+    unstar(uri)
+
+
+# ══════════════════════════════════════════════════════════════
+# dai task list
+# ══════════════════════════════════════════════════════════════
+
+@task_app.command(name="list")
+def task_list(
+    starred: Annotated[bool, Parameter(name=["--starred", "-s"], help="只列出 star 的任务")] = False,
+    all: Annotated[bool, Parameter(name=["--all", "-a"], help="列出 pool 中所有任务")] = False,
+):
+    """列出任务"""
+    ensure_dirs()
+    
+    if starred or (not all):
+        # 默认列出 star
+        uris = list_starred()
+        if uris:
+            from rich.console import Console
+            from rich.table import Table
+            from rich import box
+            
+            console = Console()
+            table = Table(title="Starred Tasks", box=box.SIMPLE)
+            table.add_column("URI", style="cyan")
+            table.add_column("Title", style="green")
+            table.add_column("State", style="yellow")
+            
+            for uri in uris:
+                data = get_task_data(uri)
+                if data:
+                    table.add_row(
+                        uri,
+                        data.get("title", "")[:40],
+                        data.get("state", ""),
+                    )
+                else:
+                    table.add_row(uri, "", "")
+            
+            console.print(table)
+            console.print(f"\n总计: {len(uris)} 个 star 任务")
+        else:
+            log.info("暂无 star 任务")
+    
+    if all:
+        uris = list_pool()
+        if uris:
+            from rich.console import Console
+            console = Console()
+            console.print(f"Pool 中共 {len(uris)} 个任务")
+            for uri in uris[:20]:
+                console.print(f"  {uri}")
+            if len(uris) > 20:
+                console.print(f"  ... 还有 {len(uris) - 20} 个")
+
+
+# ══════════════════════════════════════════════════════════════
+# dai task show
+# ══════════════════════════════════════════════════════════════
+
+@task_app.command(name="show")
+def task_show(
+    uri: Annotated[str, Parameter(help="任务 URI")],
+):
+    """查看任务详情"""
+    data = get_task_data(uri)
+    if not data:
+        log.error(f"任务不存在: {uri}")
+        sys.exit(1)
+    
+    from rich.console import Console
+    from rich.panel import Panel
+    
+    console = Console()
+    
+    title = data.get("title", "无标题")
+    state = data.get("state", "unknown")
+    subject = data.get("subject", "")
+    body = data.get("body", "")
+    
+    content = f"[bold]{title}[/bold]\n"
+    content += f"State: {state}\n"
+    if subject:
+        content += f"Subject: {subject}\n"
+    if is_starred(uri):
+        content += "Status: ⭐ starred\n"
+    content += f"\n{body[:500]}"
+    
+    console.print(Panel(content, title=uri))

--- a/pkgs/diy-cli/src/diycli/task_github.py
+++ b/pkgs/diy-cli/src/diycli/task_github.py
@@ -1,0 +1,254 @@
+"""dai task github — GitHub 任务操作"""
+
+from __future__ import annotations
+
+import sys
+import subprocess
+from typing import Annotated
+from cyclopts import App, Parameter
+
+from ._log import logger
+from .task import (
+    uri_to_pool_path, star, unstar, ensure_dirs,
+    get_task_data,
+)
+
+log = logger.with_tag("task.github")
+
+github_app = App(
+    name="github",
+    help="GitHub 任务操作",
+)
+
+
+def _parse_github_uri(uri: str) -> tuple[str, str, str] | None:
+    """解析 GitHub URI 为 (owner, repo, number)
+    
+    支持格式:
+      diy-agent/_diy/issues/42
+      github.com/diy-agent/_diy/issues/42
+    """
+    parts = uri.replace("github.com/", "").split("/")
+    if len(parts) >= 4 and parts[2] == "issues":
+        owner, repo = parts[0], parts[1]
+        try:
+            number = int(parts[3])
+            return owner, repo, number
+        except ValueError:
+            pass
+    return None
+
+
+@github_app.command(name="link")
+def github_link(
+    uri: Annotated[str, Parameter(help="GitHub issue URI (如 diy-agent/_diy/issues/42)")],
+):
+    """链接已有 issue 到池子（下载 + 自动 star）"""
+    ensure_dirs()
+    
+    parsed = _parse_github_uri(uri)
+    if not parsed:
+        log.error(f"无法解析 URI: {uri}")
+        sys.exit(1)
+    
+    owner, repo, number = parsed
+    full_uri = f"github.com/{owner}/{repo}/issues/{number}"
+    
+    # 检查是否已在池子
+    pool_path = uri_to_pool_path(full_uri)
+    if pool_path.exists():
+        log.info(f"已在池子中: {full_uri}")
+        star(full_uri)
+        return
+    
+    # 下载 issue
+    log.info(f"下载 issue #{number}...")
+    try:
+        result = subprocess.run(
+            ["gh", "issue", "view", str(number), "--repo", f"{owner}/{repo}",
+             "--json", "title,body,state,createdAt,updatedAt"],
+            capture_output=True, text=True, timeout=30,
+        )
+        
+        if result.returncode != 0:
+            log.error(f"下载失败: {result.stderr}")
+            sys.exit(1)
+        
+        import json
+        issue_data = json.loads(result.stdout)
+        
+        # 创建目录
+        pool_path.mkdir(parents=True, exist_ok=True)
+        
+        # 写 frontmatter
+        from datetime import datetime
+        now = datetime.now().strftime("%Y-%m-%dT%H:%M:%S")
+        content = f"""---
+uri: {full_uri}
+title: "{issue_data.get('title', '')}"
+state: {issue_data.get('state', 'OPEN').lower()}
+subject: 
+created: '{issue_data.get('createdAt', now)}'
+updated: '{issue_data.get('updatedAt', now)}'
+source:
+  type: github_issue
+  uri: {full_uri}
+---
+
+{issue_data.get('body', '')}
+"""
+        agents_md = pool_path / "AGENTS.md"
+        agents_md.write_text(content, encoding="utf-8")
+        
+        log.success(f"已下载: {full_uri}")
+        
+        # 自动 star
+        star(full_uri)
+        
+    except subprocess.TimeoutExpired:
+        log.error("下载超时")
+        sys.exit(1)
+    except Exception as e:
+        log.error(f"下载失败: {e}")
+        sys.exit(1)
+
+
+@github_app.command(name="sync")
+def github_sync(
+    uri: Annotated[str, Parameter(help="GitHub issue URI")],
+):
+    """刷新池子中的 issue 数据"""
+    ensure_dirs()
+    
+    parsed = _parse_github_uri(uri)
+    if not parsed:
+        log.error(f"无法解析 URI: {uri}")
+        sys.exit(1)
+    
+    owner, repo, number = parsed
+    full_uri = f"github.com/{owner}/{repo}/issues/{number}"
+    
+    pool_path = uri_to_pool_path(full_uri)
+    if not pool_path.exists():
+        log.error(f"任务不在池子中: {full_uri}")
+        log.info(f"请先 dai task github link {full_uri}")
+        sys.exit(1)
+    
+    # 重新下载
+    log.info(f"刷新 issue #{number}...")
+    try:
+        result = subprocess.run(
+            ["gh", "issue", "view", str(number), "--repo", f"{owner}/{repo}",
+             "--json", "title,body,state,createdAt,updatedAt"],
+            capture_output=True, text=True, timeout=30,
+        )
+        
+        if result.returncode != 0:
+            log.error(f"刷新失败: {result.stderr}")
+            sys.exit(1)
+        
+        import json
+        issue_data = json.loads(result.stdout)
+        
+        # 更新 frontmatter
+        from datetime import datetime
+        now = datetime.now().strftime("%Y-%m-%dT%H:%M:%S")
+        content = f"""---
+uri: {full_uri}
+title: "{issue_data.get('title', '')}"
+state: {issue_data.get('state', 'OPEN').lower()}
+subject: 
+created: '{issue_data.get('createdAt', now)}'
+updated: '{issue_data.get('updatedAt', now)}'
+source:
+  type: github_issue
+  uri: {full_uri}
+---
+
+{issue_data.get('body', '')}
+"""
+        agents_md = pool_path / "AGENTS.md"
+        agents_md.write_text(content, encoding="utf-8")
+        
+        log.success(f"已刷新: {full_uri}")
+        
+    except Exception as e:
+        log.error(f"刷新失败: {e}")
+        sys.exit(1)
+
+
+@github_app.command(name="promote")
+def github_promote(
+    task_uri: Annotated[str, Parameter(help="本地任务 URI (如 local/task/1)")],
+    repo: Annotated[str, Parameter(help="目标 GitHub 仓库 (如 diy-agent/_diy)")],
+):
+    """将本地任务升级为 GitHub issue"""
+    ensure_dirs()
+    
+    # 读取本地任务数据
+    local_data = get_task_data(task_uri)
+    if not local_data:
+        log.error(f"本地任务不存在: {task_uri}")
+        sys.exit(1)
+    
+    title = local_data.get("title", "")
+    body = local_data.get("body", "")
+    
+    # 创建 GitHub issue
+    log.info(f"创建 GitHub issue...")
+    try:
+        result = subprocess.run(
+            ["gh", "issue", "create", "--repo", repo,
+             "--title", title, "--body", body],
+            capture_output=True, text=True, timeout=30,
+        )
+        
+        if result.returncode != 0:
+            log.error(f"创建失败: {result.stderr}")
+            sys.exit(1)
+        
+        # 解析返回的 issue URL
+        # 格式: https://github.com/owner/repo/issues/123
+        issue_url = result.stdout.strip()
+        parts = issue_url.rstrip("/").split("/")
+        number = parts[-1]
+        owner_repo = "/".join(parts[-3:-1])
+        
+        new_uri = f"github.com/{owner_repo}/issues/{number}"
+        log.info(f"已创建: {new_uri}")
+        
+        # 移动数据目录
+        import shutil
+        old_path = uri_to_pool_path(task_uri)
+        new_path = uri_to_pool_path(new_uri)
+        new_path.parent.mkdir(parents=True, exist_ok=True)
+        
+        # 更新 frontmatter 中的 URI
+        agents_md = old_path / "AGENTS.md"
+        content = agents_md.read_text(encoding="utf-8")
+        content = content.replace(f"uri: {task_uri}", f"uri: {new_uri}")
+        content = content.replace(f"uri: {task_uri}", f"uri: {new_uri}", 1)
+        
+        # 移动目录
+        shutil.move(str(old_path), str(new_path))
+        
+        # 写入更新后的内容
+        (new_path / "AGENTS.md").write_text(content, encoding="utf-8")
+        
+        # 更新 star
+        from .task import uri_to_star_name
+        old_star = STAR_DIR / uri_to_star_name(task_uri)
+        if old_star.is_symlink():
+            old_star.unlink()
+        
+        star(new_uri)
+        
+        log.success(f"已升级: {task_uri} → {new_uri}")
+        
+    except Exception as e:
+        log.error(f"升级失败: {e}")
+        sys.exit(1)
+
+
+# 需要导入 STAR_DIR
+from .task import STAR_DIR

--- a/pkgs/diy-cli/src/diycli/task_local.py
+++ b/pkgs/diy-cli/src/diycli/task_local.py
@@ -1,0 +1,100 @@
+"""dai task local — 本地任务操作"""
+
+from __future__ import annotations
+
+import sys
+import uuid
+from typing import Annotated
+from cyclopts import App, Parameter
+
+from ._log import logger
+from .task import (
+    uri_to_pool_path, star, ensure_dirs,
+    get_task_data, list_pool,
+)
+
+log = logger.with_tag("task.local")
+
+local_app = App(
+    name="local",
+    help="本地任务操作",
+)
+
+
+@local_app.command(name="create")
+def local_create(
+    title: Annotated[str, Parameter(help="任务标题")],
+    detail: Annotated[str, Parameter(name=["--detail", "-d"], help="任务详情")] = "",
+    subject: Annotated[str, Parameter(name=["--subject", "-s"], help="Subject 路径")] = "",
+):
+    """创建本地任务（自动 star）"""
+    ensure_dirs()
+    from datetime import datetime
+    
+    # 生成序号（简单递增）
+    local_task_dir = uri_to_pool_path("local/task")
+    local_task_dir.mkdir(parents=True, exist_ok=True)
+    existing = [p for p in local_task_dir.iterdir() if p.is_dir()]
+    next_num = max([int(p.name) for p in existing if p.name.isdigit()] or [0]) + 1
+    
+    uri = f"local/task/{next_num}"
+    task_dir = uri_to_pool_path(uri)
+    task_dir.mkdir(parents=True, exist_ok=True)
+    
+    # 写 frontmatter
+    now = datetime.now().strftime("%Y-%m-%dT%H:%M:%S")
+    content = f"""---
+uri: {uri}
+title: "{title}"
+state: pending
+subject: {subject}
+created: '{now}'
+updated: '{now}'
+source:
+  type: local
+  uri: {uri}
+---
+
+{detail}
+"""
+    agents_md = task_dir / "AGENTS.md"
+    agents_md.write_text(content, encoding="utf-8")
+    
+    # 自动 star
+    star(uri)
+    
+    log.success(f"已创建: {uri}")
+
+
+@local_app.command(name="list")
+def local_list():
+    """列出本地任务"""
+    ensure_dirs()
+    
+    local_dir = uri_to_pool_path("local/task")
+    if not local_dir.exists():
+        log.info("暂无本地任务")
+        return
+    
+    from rich.console import Console
+    from rich.table import Table
+    from rich import box
+    
+    console = Console()
+    table = Table(title="Local Tasks", box=box.SIMPLE)
+    table.add_column("URI", style="cyan")
+    table.add_column("Title", style="green")
+    table.add_column("State", style="yellow")
+    
+    for item in sorted(local_dir.iterdir()):
+        if item.is_dir():
+            uri = f"local/task/{item.name}"
+            data = get_task_data(uri)
+            if data:
+                table.add_row(
+                    uri,
+                    data.get("title", "")[:40],
+                    data.get("state", ""),
+                )
+    
+    console.print(table)

--- a/sha.sh
+++ b/sha.sh
@@ -146,4 +146,11 @@ github-actions-cicd()    {
 # app entry script & _root cmd
 ####################################################
 
+# 隔离实验模式（数据在 .diy-dev/）
+# 用法: DIY_HOME=.diy-dev uv run diy task ...
+dev() {
+  echo "隔离模式: 数据目录 .diy-dev/"
+  echo "用法: DIY_HOME=.diy-dev uv run diy task ..."
+}
+
 sha "$@"


### PR DESCRIPTION
## 变更

### 核心设计

实现 pool + star 任务管理模型：

```
~/.diy/task/     ← pool（所有任务永久存储）
~/.diy/star/     ← focus（symlink 视图）
```

### 新增模块

- `task.py` — URI ↔ 路径映射、star/unstar 操作
- `task_cli.py` — star/unstar/list/show 命令
- `task_local.py` — local create 命令
- `task_github.py` — github link/sync/promote 命令

### 命令结构

```bash
dai task
├── star/unstar    — 关注/取消
├── list/show      — 列出/查看
├── local
│   └── create     — 创建本地任务（自动 star）
├── github
│   ├── link       — 链接已有 issue
│   ├── sync       — 刷新池子数据
│   └── promote    — 升级为 GitHub issue
```

### 测试

```bash
dai task local create --title "测试" --detail "详情"
dai task list
dai task show local/task/1
dai task unstar local/task/1
```

## 关联

- Issue: #94 (任务系统重构：pool + star 模型)
- Epic: #58 (dev架构更新)
